### PR TITLE
Add a 'ctx->' to the mouse interface

### DIFF
--- a/src/input_iface.c
+++ b/src/input_iface.c
@@ -569,8 +569,8 @@ void input_workqueue_handler(struct work_struct *work_struct_ptr)
 		#if (BBQ20KBD_TRACKPAD_USE == BBQ20KBD_TRACKPAD_AS_MOUSE)
 
 			// Report mouse movement
-			input_report_rel(input_dev, REL_X, ctx->touch_rel_x);
-			input_report_rel(input_dev, REL_Y, ctx->touch_rel_y);
+			input_report_rel(ctx->input_dev, REL_X, ctx->touch_rel_x);
+			input_report_rel(ctx->input_dev, REL_Y, ctx->touch_rel_y);
 
 			// Clear touch interrupt flag
 			ctx->touch_event_flag = 0;


### PR DESCRIPTION
Hello! I'm attempting to get the trackpad-as-mouse functionality working on my beepberry. When I tried to build it complained about these lines, and I think they were missing the ctx ref.

Now if I update the 'config.h' to use trackpad, I'm able to build and make install. Sadly I'm still not seeing any mouse or trackpad though, everything seems to keep working as before. Any steps I'm missing, or not implemented at the moment?

Thanks!