### PR TITLE
Implement rewake timer, shutdown grace timer, startup reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Adds the following sysfs entries under `/sys/firmware/beepy`:
 only.
 - `keyboard_backlight`: set keyboard brightness from 0 to 255. Write-only.
 - `battery_raw`: raw numerical battery level as reported by firmware. Read-only.
-- `battery_volts`: battery voltage estimation. Read-only
+- `battery_volts`: battery voltage estimation. Read-only.
+- `rewake_timer`: send a shutdown signal to the Pi and turn back on in this many minutes. Write-only.
+- `startup_reason`: cause of Pi boot (firmware init, power button, rewake timer)
 
 Module parameters:
 
@@ -67,6 +69,12 @@ reload the module with `beepy-kbd param=val`.
   - `meta`: default, will use the touchpad button to enable or disable meta mode.
     See section below for how to use meta mode.
   - `keys`: touchpad always on, swiping sends arrow keys, clicking sends Enter.
+- `shutdown_grace`: numeric 5-255
+  - Wait this many seconds between a driver-initiated shutdown
+    and hard power off to the Pi.
+  - If greater than `rewake_timer`, a shutdown will not be triggered when
+    `rewake_timer` is written.
+  - Default: 30 seconds. Minimum: 5 seconds
 
 ### Meta mode
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ only.
 - `battery_raw`: raw numerical battery level as reported by firmware. Read-only.
 - `battery_volts`: battery voltage estimation. Read-only.
 - `rewake_timer`: send a shutdown signal to the Pi and turn back on in this many minutes. Write-only.
-- `startup_reason`: cause of Pi boot (firmware init, power button, rewake timer)
+- `startup_reason`: cause of Pi boot (`fw_init`, `power_button`, `rewake`)
 
 Module parameters:
 

--- a/src/i2c_helper.h
+++ b/src/i2c_helper.h
@@ -9,6 +9,18 @@
 #include "registers.h"
 #include "debug_levels.h"
 
+// Parse 0 to 255 from string
+static inline int parse_u8(char const* buf)
+{
+	int rc, result;
+
+    // Parse string value
+	if ((rc = kstrtoint(buf, 10, &result)) || (result < 0) || (result > 0xff)) {
+		return -EINVAL;
+	}
+	return result;
+}
+
 // Read a single uint8_t value from I2C register
 static inline int kbd_read_i2c_u8(struct i2c_client* i2c_client, uint8_t reg_addr,
 	uint8_t* dst)

--- a/src/main.c
+++ b/src/main.c
@@ -113,5 +113,5 @@ module_exit(beepy_kbd_exit);
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("wallComputer and Andrew D'Angelo <dangeloandrew@outlook.com>");
-MODULE_DESCRIPTION("BB Classic keyboard driver for Beepberry");
-MODULE_VERSION("2.2");
+MODULE_DESCRIPTION("BB Classic keyboard driver for Beepy");
+MODULE_VERSION("2.3");

--- a/src/params_iface.c
+++ b/src/params_iface.c
@@ -159,7 +159,7 @@ static const struct kernel_param_ops shutdown_grace_param_ops = {
 };
 
 module_param_cb(shutdown_grace, &shutdown_grace_param_ops, &shutdown_grace_setting, 0664);
-MODULE_PARM_DESC(shutdown_grace_setting, "Set to 1 to invoke /sbin/poweroff when power key is held");
+MODULE_PARM_DESC(shutdown_grace_setting, "Set delay in seconds from shutdown signal to poweroff");
 
 // No setup
 int params_probe(void)

--- a/src/params_iface.c
+++ b/src/params_iface.c
@@ -17,6 +17,7 @@
 // Kernel module parameters
 static char* touchpad_setting = "meta"; // Use meta mode by default
 static char* handle_poweroff_setting = "0"; // Enable to have module invoke poweroff
+static char* shutdown_grace_setting = "30"; // 30 seconds between shutdown signal and poweroff
 
 // Update touchpad setting in global context, if available
 static int set_touchpad_setting(struct kbd_ctx *ctx, char const* val)
@@ -109,6 +110,56 @@ static const struct kernel_param_ops handle_poweroff_setting_param_ops = {
 
 module_param_cb(handle_poweroff, &handle_poweroff_setting_param_ops, &handle_poweroff_setting, 0664);
 MODULE_PARM_DESC(handle_poweroff_setting, "Set to 1 to invoke /sbin/poweroff when power key is held");
+
+// Update shutdown grace time in firmware
+static int set_shutdown_grace_setting(struct kbd_ctx *ctx, char const* val)
+{
+	int parsed_val;
+
+	// If no state was passed, exit
+	if (!ctx) {
+		return 0;
+	}
+
+	// Parse setting
+	if ((parsed_val = parse_u8(val)) < 0) {
+		return parsed_val;
+	}
+
+	// Check setting (minimum 5 seconds)
+	if ((parsed_val < 5) || (parsed_val > 255)) {
+		return -EINVAL;
+	}
+
+	// Write setting to firmware
+	(void)kbd_write_i2c_u8(ctx->i2c_client, REG_SHUTDOWN_GRACE, (uint8_t)parsed_val);
+
+	return 0;
+}
+
+// Time between shutdown signal and power off in seconds
+static int shutdown_grace_param_set(const char *val, const struct kernel_param *kp)
+{
+	char *stripped_val;
+	char stripped_val_buf[4];
+
+	// Copy provided value to buffer and strip it of newlines
+	strncpy(stripped_val_buf, val, 4);
+	stripped_val_buf[3] = '\0';
+	stripped_val = strstrip(stripped_val_buf);
+
+	return (set_shutdown_grace_setting(g_ctx, stripped_val) < 0)
+		? -EINVAL
+		: param_set_charp(stripped_val, kp);
+}
+
+static const struct kernel_param_ops shutdown_grace_param_ops = {
+	.set = shutdown_grace_param_set,
+	.get = param_get_charp,
+};
+
+module_param_cb(shutdown_grace, &shutdown_grace_param_ops, &shutdown_grace_setting, 0664);
+MODULE_PARM_DESC(shutdown_grace_setting, "Set to 1 to invoke /sbin/poweroff when power key is held");
 
 // No setup
 int params_probe(void)

--- a/src/registers.h
+++ b/src/registers.h
@@ -108,8 +108,8 @@
 #define REG_LED_G 						0x22
 #define REG_LED_B 						0x23
 
-#define REG_REWAKE_TIME 0x24
-#define REG_REWAKE 0x25
+#define REG_REWAKE_MINS 0x24
+#define REG_SHUTDOWN_GRACE 0x25
 
 #define REG_RTC_SEC 0x26
 #define REG_RTC_MIN 0x27
@@ -120,6 +120,11 @@
 #define REG_RTC_COMMIT 0x2C
 
 #define REG_DRIVER_STATE 0x2D
+
+#define REG_STARTUP_REASON 0x2E
+#define STARTUP_REASON_FW_INIT 0x1
+#define STARTUP_REASON_BUTTON 0x2
+#define STARTUP_REASON_REWAKE 0x3
 
 #endif
 


### PR DESCRIPTION
New entries in `/sys/firmware/beepy/`

- `rewake_timer`: send a shutdown signal to the Pi and turn back on in this many minutes. Write-only.
- `startup_reason`: cause of Pi boot (firmware init, power button, rewake timer). Read only.

New module parameters

- `shutdown_grace`: numeric 5-255
  - Wait this many seconds between a driver-initiated shutdown
    and hard power off to the Pi.
  - If greater than `rewake_timer`, a shutdown will not be triggered when `rewake_timer` is written.
  - Default: 30 seconds. Minimum: 5 seconds