### PR TITLE
Display Meta overlay when short hold Berry key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,143 @@
 # Beepy keyboard driver
 
-Originally bbqX0kbd
+## Alt and Sym modifiers
+
+The alternate symbols printed directly on the Beepy keys are triggered by pressing the physical Alt key, then the key on which the symbol is printed.
+
+For additional symbols not printed directly on the keys, the Sym key is used. Sym sends AltGr (Right Alt), which is mapped to more symbols via the keymap file at `/usr/share/kbd/keymaps/beepy-kbd.map`.
+
+## Sticky modifier keys
+
+The keyboard driver supports sticky modifier keys. Holding a modifier key (Shift, Alt, Sym) while typing an alpha keys will apply the modifier to all alpha keys until the modifier is released.
+
+One press and release of the modifier will enter sticky mode, applying the modifier to the next alpha key only. If the same modifier key is pressed and released again in sticky mode, it will be canceled.
+
+Visual mode indicators are drawn in the top right corner of the display, with indicators for Shift, Physical Alt, Control, Alt, Symbol, and Meta mode.
+
+## Other key mappings
+
+- Physical Alt + Enter is mapped to Tab
+- Holding Shift temporarily enables the touch sensor until Shift is released
+
+- Single click
+	- Call: Control
+	- Berry: Enter Meta mode (see the section on Meta Mode)
+	- Touchpad: Enable optical touch sensor, sending arrow keys. Subsequent clicks send Enter
+	- Back: Escape
+	- End Call: Tmux prefix (customize the prefix in the keymap file)
+
+- Short hold (1 second)
+	- Call: Lock Control
+	- Berry: Display Meta mode overlay (requires `beepy-symbol-overlay` package)
+	- End Call: Open Tmux menu (requires `beepy-tmux-menus` package and Tmux configuration)
+	- Symbol: Display Symbol overlay (requires `beepy-symbol-overlay` package)
+
+- Long hold (5 seconds)
+	- End call: send shutdown signal to Pi
+
+## Meta mode
+
+Meta mode is a modal layer that assists in rapidly moving the cursor and scrolling with single keypresses. To enter Meta mode, click the touchpad button once. Then, the following keymap is applied, staying in Meta mode until dismissed:
+
+- E: up, S: down, W: left, D: right
+    - Why not WASD? This way, you can place your thumb in the middle of all four of these keys, and more fluidly move the cursor without mistyping
+- R: Home, F: End, O: PageUp, P: PageDown
+- Q: Alt+Left (back one word), A: Alt+Right (forward one word)
+- T: Tab (dismisses meta mode)
+- X: Apply Control to next key (dismisses meta mode)
+- C: Apply Alt to next key (dismisses meta mode)
+- 0: Toggle Sharp display inversion
+- N: Decrease keyboard brightness
+- M: Increase keyboard brightness
+- $: Toggle keyboard backlight
+- Esc: (Back button): exit meta mode
+
+Typing any other key while in Meta mode will exit Meta mode and send the key as if it was typed normally.
+
+## `sysfs` Interface
+
+The following sysfs entries are available under `/sys/firmware/beepy`:
+
+- `led`: 0 to disable LED, 1 to enable. Write-only
+- `led_red`, `led_green`, `led_blue`: set LED color intensity from 0 to 255. Write- only
+- `keyboard_backlight`: set keyboard brightness from 0 to 255. Write-only
+- `battery_raw`: raw numerical battery level as reported by firmware. Read-only
+- `battery_volts`: battery voltage estimation. Read-only
+- `battery_percent`: battery percentage estimation. Read-only
+
+## Module parameters
+
+Write to `/sys/module/beepy_kbd/parameters/<param>` to set, or unload and reload the module with `beepy-kbd param=val`.
+
+- `touch_act`: one of `click` or `always`
+  - `click`: default, will disable touchpad until the touchpad button is clicked
+  - `always`: touchpad always on, swiping sends touch input, clicking sends Enter
+- `touch_as`: one of `keys` or `mouse`
+  - `keys`: default, send arrow keys with the touchpad
+  - `mouse`: send mouse input (useful for X11)
+- `touch_shift`: default on. Send touch input while the Shift key is held
+- `sharp_path`: Sharp DRM device to send overlay commands. Default: `/dev/dri/card0`
+
+## Custom Keymap
+
+The Alt and Sym keymaps and the Tmux prefix sent by the "Berry" key can be edited in the file `/usr/share/kbd/keymaps/beepy-kbd.map`. To reapply the keymap without rebooting, run `loadkeys /usr/share/kbd/keymaps/beepy-kbd.map`.
+
+## Firmware update
+
+Starting with Beepy firmware 3.0, firmware is loaded in two stages.
+
+The first stage is a modified version of [pico-flashloader](https://github.com/rhulme/pico-flashloader).
+It allows updates to be flashed to the second stage firmware while booted.
+
+The second stage is the actual Beepy firmware.
+
+Firmware updates are flashed by writing to `/sys/firmware/beepy/fw_update`:
+
+- Header line beginning with `+` e.g. `+Beepy`
+- Followed by the contents of an image in Intel HEX format
+
+If the update completes successfully, the system will be rebooted.
+There is a delay configurable at `/sys/firmware/beepy/shutdown_grace` to allow the operating system to cleanly shut down before the Pi is powered off.
+The firmware is flashed right before the Pi boots back up, so please wait until the system reboots on its own before removing power.
+
+If the update failed, an error will be returned and the firmware will not be modified. Check `dmesg | tail` for more information.
+
+## Pre-requisites
+
+- Software Pre-requisites
+
+  1. The Raspberry Pi must have kernel drivers installed on it.
+     ```bash
+     sudo apt install raspberrypi-kernel-headers
+     ```
+  2. The Pi must have its I2C Peripheral enabled. Run `sudo raspi-config`, then under `Interface Options`, enable `I2C`.
+
+- Hardware Pre-rquisties: Keyboard to Raspberry Pi Hardware connections.
+   0. If using the keyboard without interrupt pin (How to do so is discussed below under `Installation Options`), make the following connections:
+      ```
+      3.3V on Pi --> 3.3V on Keyboard Module.```
+      ```GND on Pi --> GND on Keyboard Module.```
+      ```SCL(Pi Pin 5/BCM GPIO 3) on Pi --> SCL on Keyboard Module.```
+      ```SDA(Pi Pin 3/BCM GPIO 2) on Pi --> SDA on Keyboard Module.``` 
+   1. If Interrupt Pin is used, the pin is identified from the BCM Pin Number and not the Raspberry Pi GPIO Pin number.
+
+  Check pre-requisites with the command `i2cdetect -y 1`(one might need `sudo`). They keyboard should be on the address `0x1F`. If you are using the [Keyboard FeatherWing](https://www.tindie.com/products/arturo182/keyboard-featherwing-qwerty-keyboard-26-lcd/), the Touch sensor on the screen will also show up on `0x4B`.
+
+## Installation
+
+To build, install, and enable the kernel module:
+
+	make
+	sudo make install
+
+To remove:
+
+	sudo make uninstall
+
+## Customisation
+
+- The Settings of the LCD can be changed as shown in [fbcp-ili9341](https://github.com/juj/fbcp-ili9341.git). Notably, the Data_Command Pin can be changed and Clock speed can be increased.
+- Look at the `beepy-kbd.map` file for alternate key binds. Edit it as per your need and put the new map file in correct folder (as per `installer.sh`) to be loaded correctly in `/etc/default/keyboard`. One can use `sudo loadkeys path/to/beepy-kbd.map` while the driver is running, and press keys to check their new key bindings before placing it in the right location. Once satisfied with your keymap, run `./remover.sh &&  ./installer.sh` to reinstall everything correctly.
 
 ## Cleaning old drivers
 
@@ -28,140 +165,6 @@ Remove the following lines from `/etc/modules`:
 
 * `bbqX0kbd`
 * `sharp`
-
-## Modifications
-
-- Supports sticky modifier keys. Must be used with the corresponding RP2040 firmware
-  - Holding a modifier key (shift, physical alt, Symbol) while typing an alpha keys will apply the modifier to all alpha keys until the modifier is released.
-  - One press and release of the modifier will enter sticky mode, applying the modifier to the next alpha key only. If the same modifier key is pressed and released again in sticky mode, it will be canceled.
-- Call is mapped to Control
-- Berry key enters Meta mode for cursor movement (described in a later section)
-- Touchpad click enables touch. Configurable to always send touch
-- Back is mapped to Escape
-- Pressing End Call is mapped to Tmux prefix (customize the prefix in the keymap file)
-- Holding End Call for 5 seconds will shut down the Pi
-- Physical Alt is mapped to symbols via the keymap file
-- Symbol is mapped to AltGr (Right Alt), mapped to more symbols via the keymap file
-- Physical Alt + Enter is mapped to Tab
-
-Integrates with [Sharp DRM driver](https://github.com/ardangelo/sharp-drm-driver)
-
-- Draws visual mode indicators over display contents
-- Indicators for Shift, Phys. Alt, Control, Alt, Symbol, Meta mode
-- Meta mode key 0 toggles display color inversion
-
-Adds the following sysfs entries under `/sys/firmware/beepy`:
-
-- `led`: 0 to disable LED, 1 to enable. Write-only.
-- `led_red`, `led_green`, `led_blue`: set LED color intensity from 0 to 255. Write-
-only.
-- `keyboard_backlight`: set keyboard brightness from 0 to 255. Write-only.
-- `battery_raw`: raw numerical battery level as reported by firmware. Read-only.
-- `battery_volts`: battery voltage estimation. Read-only.
-- `rewake_timer`: send a shutdown signal to the Pi and turn back on in this many minutes. Write-only.
-- `startup_reason`: cause of Pi boot (`fw_init`, `power_button`, `rewake`). Read-only.
-- `fw_version`: current firmware version. Read-only.
-- `fw_update`: flash a new second-stage firmware. Write-only.
-
-Module parameters:
-
-Write to `/sys/module/beepy_kbd/parameters/<param>` to set, or unload and
-reload the module with `beepy-kbd param=val`.
-
-- `touch_act`: one of `click` or `always`
-  - `click`: default, will disable touchpad until the touchpad button is clicked
-  - `always`: touchpad always on, swiping sends touch input, clicking sends Enter
-- `touch_as`: one of `keys` or `mouse`
-  - `keys`: default, send arrow keys with the touchpad
-  - `mouse`: send mouse input (useful for X11)
-- `touch_shift`: default on. Send touch input while the Shift key is held
-- `shutdown_grace`: numeric 5-255
-  - Wait this many seconds between a driver-initiated shutdown
-    and hard power off to the Pi
-  - If greater than `rewake_timer`, a shutdown will not be triggered when
-    `rewake_timer` is written
-  - Default: 30 seconds. Minimum: 5 seconds
-
-### Meta mode
-
-Meta mode is a modal layer that assists in rapidly moving the cursor and scrolling
-with single keypresses.
-To enter meta mode, click the Berry key. A Star indicator will appear in the top-right corner of the screen while in meta mode.
-The following keymap is applied, staying in meta mode until dismissed:
-
-- E: up, S: down, W: left, D: right. Why not WASD? This way, you can place your thumb in the middle of  all four of these keys, and more fluidly move the cursor without mistyping.
-- R: Home, F: End, O: PageUp, P: PageDown
-- Q: Alt+Left (back one word), A: Alt+Right (forward one word)
-- T: Tab (dismisses meta mode)
-- X: Apply Control to next key (dismisses meta mode)
-- C: Apply Alt to next key (dismisses meta mode)
-- 0: Toggle Sharp display inversion
-- N: Decrease keyboard brightness
-- M: Increase keyboard brightness
-- $: Toggle keyboard backlight
-- Esc: (Back button): exit meta mode
-
-Typing any other key while in meta mode will exit meta mode and send the key as if it was typed normally.
-
-### Firmware update
-
-Starting with Beepy firmware 3.0, firmware is loaded in two stages.
-
-The first stage is a modified version of [pico-flashloader](https://github.com/rhulme/pico-flashloader).
-It allows updates to be flashed to the second stage firmware while booted.
-
-The second stage is the actual Beepy firmware.
-
-Firmware updates are flashed by writing to `/sys/firmware/beepy/fw_update`:
-
-- Header line beginning with `+` e.g. `+Beepy`
-- Followed by the contents of an image in Intel HEX format
-
-If the update completes successfully, the system will be rebooted.
-There is a delay configurable at `/sys/firmware/beepy/shutdown_grace` to allow the operating system to cleanly shut down before the Pi is powered off.
-The firmware is flashed right before the Pi boots back up, so please wait until the system reboots on its own before removing power.
-
-If the update failed, an error will be returned and the firmware will not be modified. Check `dmesg | tail` for more information.
-
-## Pre-requisites, Download, and Installation.
-
-### Pre-requisites
-
-- Software Pre-requisites
-
-  1. The Raspberry Pi must have kernel drivers installed on it.
-     ```bash
-     sudo apt install raspberrypi-kernel-headers
-     ```
-  2. The Pi must have its I2C Peripheral enabled. Run `sudo raspi-config`, then under `Interface Options`, enable `I2C`.
-
-- Hardware Pre-rquisties: Keyboard to Raspberry Pi Hardware connections.
-   0. If using the keyboard without interrupt pin (How to do so is discussed below under `Installation Options`), make the following connections:
-      ```
-      3.3V on Pi --> 3.3V on Keyboard Module.```
-      ```GND on Pi --> GND on Keyboard Module.```
-      ```SCL(Pi Pin 5/BCM GPIO 3) on Pi --> SCL on Keyboard Module.```
-      ```SDA(Pi Pin 3/BCM GPIO 2) on Pi --> SDA on Keyboard Module.``` 
-   1. If Interrupt Pin is used, the pin is identified from the BCM Pin Number and not the Raspberry Pi GPIO Pin number.
-
-  Check pre-requisites with the command `i2cdetect -y 1`(one might need `sudo`). They keyboard should be on the address `0x1F`. If you are using the [Keyboard FeatherWing](https://www.tindie.com/products/arturo182/keyboard-featherwing-qwerty-keyboard-26-lcd/), the Touch sensor on the screen will also show up on `0x4B`.
-
-### Installation
-
-To build, install, and enable the kernel module:
-
-	make
-	sudo make install
-
-To remove:
-
-	sudo make uninstall
-
-## Customisation
-
-
-- The Settings of the LCD can be changed as shown in [fbcp-ili9341](https://github.com/juj/fbcp-ili9341.git). Notably, the Data_Command Pin can be changed and Clock speed can be increased.
-- Look at the `beepy-kbd.map` file for alternate key binds. Edit it as per your need and put the new map file in correct folder (as per `installer.sh`) to be loaded correctly in `/etc/default/keyboard`. One can use `sudo loadkeys path/to/beepy-kbd.map` while the driver is running, and press keys to check their new key bindings before placing it in the right location. Once satisfied with your keymap, run `./remover.sh &&  ./installer.sh` to reinstall everything correctly.
 
 ## Contributing
 Pull requests are welcome. 

--- a/beepy-kbd.map
+++ b/beepy-kbd.map
@@ -36,7 +36,7 @@ altgr keycode 113 = dollar
 # Press power key sends Control + this code
 # Use it for Tmux prefix
 control keycode 171 = Control_b
- Short hold power key sends Tmux prefix + this key 
+# Short hold power key sends Tmux prefix + this key 
 control keycode 174 = e
 
 # Meta Q / A move between words

--- a/beepy-kbd.map
+++ b/beepy-kbd.map
@@ -33,9 +33,11 @@ altgr keycode 50 = guillemotright
 
 altgr keycode 113 = dollar
 
-# Berry key sends Control + this code
+# Press power key sends Control + this code
 # Use it for Tmux prefix
 control keycode 171 = Control_b
+ Short hold power key sends Tmux prefix + this key 
+control keycode 174 = e
 
 # Meta Q / A move between words
 keycode 172 = F172

--- a/src/input_display.c
+++ b/src/input_display.c
@@ -5,14 +5,13 @@
 
 #include "config.h"
 #include "input_iface.h"
+#include "params_iface.h"
 
 #include "indicators.h"
 
 // Display ioctl
 
 #define DRM_SHARP_REDRAW 0x00
-
-#define SHARP_DEVICE_PATH "/dev/dri/card0"
 
 // Globals
 
@@ -66,7 +65,15 @@ static int ioctl_call_uint32(char const* path, unsigned int cmd, uint32_t value)
 
 static int ioctl_sharp_redraw(void)
 {
-	return ioctl_call_uint32(SHARP_DEVICE_PATH,
+	return ioctl_call_uint32(params_get_sharp_path(),
+		DRM_IO(DRM_COMMAND_BASE + DRM_SHARP_REDRAW), 0);
+}
+
+// Whether this is a path to a valid Sharp display device
+int input_display_valid_sharp_path(char const* path)
+{
+	// Try to refresh screen
+	return ioctl_call_uint32(path,
 		DRM_IO(DRM_COMMAND_BASE + DRM_SHARP_REDRAW), 0);
 }
 

--- a/src/input_display.c
+++ b/src/input_display.c
@@ -64,19 +64,28 @@ static int ioctl_call_uint32(char const* path, unsigned int cmd, uint32_t value)
 	return 0;
 }
 
+static int ioctl_sharp_redraw(void)
+{
+	return ioctl_call_uint32(SHARP_DEVICE_PATH,
+		DRM_IO(DRM_COMMAND_BASE + DRM_SHARP_REDRAW), 0);
+}
+
 // Invert display colors by writing to display driver parameter
 void input_display_invert(struct kbd_ctx* ctx)
 {
 	// Update saved invert value
 	g_mono_invert = (g_mono_invert) ? 0 : 1;
 
-	// Write to parameter
-	if ((__sharp_memory_set_invert = symbol_get(sharp_memory_set_invert))) {
-		__sharp_memory_set_invert(g_mono_invert);
-
-		(void)ioctl_call_uint32(SHARP_DEVICE_PATH,
-			DRM_IO(DRM_COMMAND_BASE + DRM_SHARP_REDRAW), 0);
+	if (__sharp_memory_set_invert == NULL) {
+		__sharp_memory_set_invert = symbol_get(sharp_memory_set_invert);
 	}
+	if (__sharp_memory_set_invert == NULL) {
+		return;
+	}
+
+	// Apply invert value
+	__sharp_memory_set_invert(g_mono_invert);
+	(void)ioctl_sharp_redraw();
 }
 
 // Set display indicator
@@ -91,43 +100,55 @@ void input_display_set_indicator(int idx, unsigned char const* pixels)
 	if (g_mod_overlays[idx].storage == NULL) {
 		x = - ((idx + 1) * INDICATOR_WIDTH);
 
-		if ((__sharp_memory_add_overlay = symbol_get(sharp_memory_add_overlay))) {
-			g_mod_overlays[idx].storage = __sharp_memory_add_overlay(
-				x, 0, INDICATOR_WIDTH, INDICATOR_HEIGHT, pixels);
-		} else {
+		// Get overlay add function
+		if (__sharp_memory_add_overlay == NULL) {
+			__sharp_memory_add_overlay = symbol_get(sharp_memory_add_overlay);
+		}
+		if (__sharp_memory_add_overlay == NULL) {
 			return;
 		}
+
+		// Add indicator overlay
+		g_mod_overlays[idx].storage = __sharp_memory_add_overlay(
+			x, 0, INDICATOR_WIDTH, INDICATOR_HEIGHT, pixels);
 	}
 
 	if (g_mod_overlays[idx].display == NULL) {
-		if ((__sharp_memory_show_overlay = symbol_get(sharp_memory_show_overlay))) {
-			g_mod_overlays[idx].display = __sharp_memory_show_overlay(
-				g_mod_overlays[idx].storage);
-		} else {
+
+		if (__sharp_memory_show_overlay == NULL) {
+			__sharp_memory_show_overlay = symbol_get(sharp_memory_show_overlay);
+		}
+		if (__sharp_memory_show_overlay == NULL) {
 			return;
 		}
+
+		// Display indicator overlay and set display handle
+		g_mod_overlays[idx].display = __sharp_memory_show_overlay(
+			g_mod_overlays[idx].storage);
 	}
 
 	// Refresh display
-	(void)ioctl_call_uint32(SHARP_DEVICE_PATH, 
-		DRM_IO(DRM_COMMAND_BASE + DRM_SHARP_REDRAW), 0);
+	(void)ioctl_sharp_redraw();
 }
 
 // Clear display indicator
 void input_display_clear_indicator(int idx)
 {
 	if (g_mod_overlays[idx].display != NULL) {
-		if ((__sharp_memory_hide_overlay = symbol_get(sharp_memory_hide_overlay))) {
-			__sharp_memory_hide_overlay(g_mod_overlays[idx].display);
-			g_mod_overlays[idx].display = NULL;
-		} else {
+
+		// Get overlay hide function
+		if (__sharp_memory_hide_overlay == NULL) {
+			__sharp_memory_hide_overlay = symbol_get(sharp_memory_hide_overlay);
+		}
+		if (__sharp_memory_hide_overlay == NULL) {
 			return;
 		}
-	}
 
-	// Refresh display
-	(void)ioctl_call_uint32(SHARP_DEVICE_PATH, 
-		DRM_IO(DRM_COMMAND_BASE + DRM_SHARP_REDRAW), 0);
+		// Hide overlay and reset display handle
+		__sharp_memory_hide_overlay(g_mod_overlays[idx].display);
+		g_mod_overlays[idx].display = NULL;
+		(void)ioctl_sharp_redraw();
+	}
 }
 
 // Clear all overlays
@@ -135,49 +156,39 @@ void input_display_clear_overlays(void)
 {
 	int i;
 
-	if ((__sharp_memory_clear_overlays = symbol_get(sharp_memory_clear_overlays))) {
-		__sharp_memory_clear_overlays();
-
-		// Invalidate all overlays
-		for (i = 0; i < MAX_INDICATORS; i++) {
-			g_mod_overlays[i].storage = NULL;
-			g_mod_overlays[i].display = NULL;
-		}
-		
-		// Refresh display
-		(void)ioctl_call_uint32(SHARP_DEVICE_PATH, 
-			DRM_IO(DRM_COMMAND_BASE + DRM_SHARP_REDRAW), 0);
+	// Get overlay clear function
+	if (__sharp_memory_clear_overlays == NULL) {
+		__sharp_memory_clear_overlays = symbol_get(sharp_memory_clear_overlays);
 	}
-}
-
-int input_display_probe(struct i2c_client* i2c_client, struct kbd_ctx *ctx)
-{
-	int i;
-
-	g_mono_invert = 0;
-
-	// Clear all indicator overlays
-	if ((__sharp_memory_clear_overlays = symbol_get(sharp_memory_clear_overlays))) {
-		__sharp_memory_clear_overlays();
+	if (__sharp_memory_clear_overlays == NULL) {
+		return;
 	}
+
+	// Invalidate all overlays
 	for (i = 0; i < MAX_INDICATORS; i++) {
 		g_mod_overlays[i].storage = NULL;
 		g_mod_overlays[i].display = NULL;
 	}
+
+	// Clear all overlays
+	__sharp_memory_clear_overlays();
+
+	// Refresh display
+	(void)ioctl_sharp_redraw();
+}
+
+int input_display_probe(struct i2c_client* i2c_client, struct kbd_ctx *ctx)
+{
+	g_mono_invert = 0;
+
+	// Clear all overlays
+	input_display_clear_overlays();
 
 	return 0;
 }
 
 void input_display_shutdown(struct i2c_client* i2c_client, struct kbd_ctx *ctx)
 {
-	int i;
-
-	// Clear all indicator overlays
-	if ((__sharp_memory_clear_overlays = symbol_get(sharp_memory_clear_overlays))) {
-		__sharp_memory_clear_overlays();
-	}
-	for (i = 0; i < MAX_INDICATORS; i++) {
-		g_mod_overlays[i].storage = NULL;
-		g_mod_overlays[i].display = NULL;
-	}
+	// Clear all overlays
+	input_display_clear_overlays();
 }

--- a/src/input_iface.c
+++ b/src/input_iface.c
@@ -53,12 +53,20 @@ static void key_report_event(struct kbd_ctx* ctx,
 		return;
 	}
 
-	// Pressing power button sends Tmux prefix (Control + code 171 in keymap)
 	if (keycode == KEY_STOP) {
+
+		// Pressing power button sends Tmux prefix (Control + code 171 in keymap)
 		if (ev->state == KEY_STATE_PRESSED) {
 			input_report_key(ctx->input_dev, KEY_LEFTCTRL, TRUE);
 			input_report_key(ctx->input_dev, 171, TRUE);
 			input_report_key(ctx->input_dev, 171, FALSE);
+			input_report_key(ctx->input_dev, KEY_LEFTCTRL, FALSE);
+
+		// Short hold power buttion opens Tmux menu (Control + code 174 in keymap)
+		} else if (ev->state == KEY_STATE_HOLD) {
+			input_report_key(ctx->input_dev, KEY_LEFTCTRL, TRUE);
+			input_report_key(ctx->input_dev, 174, TRUE);
+			input_report_key(ctx->input_dev, 174, FALSE);
 			input_report_key(ctx->input_dev, KEY_LEFTCTRL, FALSE);
 		}
 		return;

--- a/src/input_iface.h
+++ b/src/input_iface.h
@@ -115,6 +115,8 @@ void input_rtc_shutdown(struct i2c_client* i2c_client, struct kbd_ctx *ctx);
 int input_display_probe(struct i2c_client* i2c_client, struct kbd_ctx *ctx);
 void input_display_shutdown(struct i2c_client* i2c_client, struct kbd_ctx *ctx);
 
+int input_display_valid_sharp_path(char const* path);
+
 void input_display_invert(struct kbd_ctx* ctx);
 
 void input_display_set_indicator(int idx, unsigned char const* pixels);

--- a/src/input_modifiers.c
+++ b/src/input_modifiers.c
@@ -11,12 +11,12 @@
 #include "debug_levels.h"
 
 #include "input_iface.h"
+#include "params_iface.h"
 
 #include "bbq20kbd_pmod_codes.h"
 
 #include "indicators.h"
 
-#define SHARP_DEVICE_PATH "/dev/dri/card0"
 #define SYMBOL_OVERLAY_PATH "/sbin/symbol-overlay"
 
 struct sticky_modifier
@@ -112,11 +112,12 @@ static uint8_t map_phys_alt_keycode(struct kbd_ctx* ctx, uint8_t keycode)
 // Will return normally if overlay is not installed
 static void show_sym_menu(struct kbd_ctx* ctx, struct sticky_modifier* sticky_modifier)
 {
+	static char const* overlay_argv[] = {SYMBOL_OVERLAY_PATH, NULL, NULL};
+
 	g_showing_sym_menu = 1;
 
-	// Call symbol menu helper
-	static char const* overlay_argv[] = {
-		SYMBOL_OVERLAY_PATH, SHARP_DEVICE_PATH, NULL};
+	// Call overlay helper
+	overlay_argv[1] = params_get_sharp_path();
 	call_usermodehelper(overlay_argv[0], (char**)overlay_argv, NULL, UMH_NO_WAIT);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -114,4 +114,4 @@ module_exit(beepy_kbd_exit);
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("wallComputer and Andrew D'Angelo <dangeloandrew@outlook.com>");
 MODULE_DESCRIPTION("BB Classic keyboard driver for Beepy");
-MODULE_VERSION("2.6");
+MODULE_VERSION("2.7");

--- a/src/params_iface.h
+++ b/src/params_iface.h
@@ -11,4 +11,6 @@
 int params_probe(void);
 void params_shutdown(void);
 
+char const* params_get_sharp_path(void);
+
 #endif


### PR DESCRIPTION
* Add parameter `sharp_path` for Sharp display device
* Send Tmux prefix + e on Power short hold, for opening Tmux menu.